### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/lib/pouch-graphql/resolver.js
+++ b/lib/pouch-graphql/resolver.js
@@ -1,5 +1,5 @@
 const PouchDB = require('./pouchdb');
-const uuid = require('node-uuid');
+const uuid = require('uuid');
 const utils = require('./utils');
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "lodash": "^4.16.4",
     "morgan": "^1.7.0",
     "node-fetch": "^1.6.3",
-    "node-uuid": "^1.4.7",
     "paint-console": "0.0.1",
     "parse-data-url": "^0.1.2",
     "pouchdb": "^6.0.7",
@@ -53,7 +52,8 @@
     "pouchdb-core": "^6.0.7",
     "pouchdb-find": "^0.10.3",
     "response-time": "^2.3.1",
-    "serve-favicon": "^2.3.0"
+    "serve-favicon": "^2.3.0",
+    "uuid": "^3.0.0"
   },
   "devDependencies": {
     "eslint": "^3.8.0",


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.