### PR TITLE
 fixes #43 (build errors on node 10+)

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,10 @@
     "grunt-nodemon": "^0.4.2",
     "mocha": "^2.5.3"
   },
+  "resolutions": {
+    "nan": "2.14.1",
+    "node-gyp": "5.1.0"
+  },
   "eslintConfig": {
     "env": {
       "node": true


### PR DESCRIPTION
no member named ‘ForceSet’ errors were occurring. Updated package.json to force nan and node-gyp dependencies to a higher version.

fixes #43 